### PR TITLE
ci(helm): bump Tunnel version to 0.61.1 for Tunnel Helm Chart 0.13.1

### DIFF
--- a/helm/tunnel/Chart.yaml
+++ b/helm/tunnel/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: tunnel
-version: 0.13.0
-appVersion: 0.61.0
+version: 0.13.1
+appVersion: 0.61.1
 description: Tunnel helm chart
 keywords:
   - scanner


### PR DESCRIPTION
This PR bumps Tunnel up to the 0.61.1 version for the Tunnel Helm chart 0.13.1.